### PR TITLE
fix: add the clusterrole of event for controller

### DIFF
--- a/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
@@ -34,6 +34,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["event"]
+    verbs: ["get", "list", "watch", "create", "patch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After I run the controller, I found the error msg like below

```bash
E0703 15:18:34.954040       1 event.go:260] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"external-health-monitor-leader-io-kubernetes-storage-mock.161e471e9d67dbdc", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Lease", Namespace:"default", Name:"external-health-monitor-leader-io-kubernetes-storage-mock", UID:"c4bd708a-cf58-4b1d-9c78-43f641a476af", APIVersion:"coordination.k8s.io/v1", ResourceVersion:"4951090", FieldPath:""}, Reason:"LeaderElection", Message:"csi-external-health-monitor-controller-8c69ff5db-czlk6 became leader", Source:v1.EventSource{Component:"external-health-monitor-leader-io.kubernetes.storage.mock/csi-external-health-monitor-controller-8c69ff5db-czlk6", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbfb7f0f2b8b177dc, ext:5871387895, loc:(*time.Location)(0x23723a0)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbfb7f0f2b8b177dc, ext:5871387895, loc:(*time.Location)(0x23723a0)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:default:csi-external-health-monitor-controller" cannot create resource "events" in API group "" in the namespace "default"' (will not retry!)
```

It is due to controller want to operate the Event resource, but it lacks of rbac permission of event. So I added it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None

```
