### PR TITLE
fix: assign node name to agent

### DIFF
--- a/cmd/csi-external-health-monitor-agent/main.go
+++ b/cmd/csi-external-health-monitor-agent/main.go
@@ -138,8 +138,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	monitorAgent := monitoragent.NewPVMonitorAgent(clientset, storageDriver, csiConn, *timeout, *monitorInterval, factory.Core().V1().PersistentVolumes(),
+	monitorAgent, err := monitoragent.NewPVMonitorAgent(clientset, storageDriver, csiConn, *timeout, *monitorInterval, factory.Core().V1().PersistentVolumes(),
 		factory.Core().V1().PersistentVolumeClaims(), factory.Core().V1().Pods(), supportStageUnstage, *kubeletRootPath)
+	if err != nil {
+		klog.Error(err.Error())
+		os.Exit(1)
+	}
 
 	run := func(ctx context.Context) {
 		stopCh := ctx.Done()

--- a/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
+++ b/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
@@ -23,10 +23,10 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
           env:
-            - name: MY_NAME
+            - name: NODE_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.name
+                  fieldPath: spec.nodeName
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/mock.socket
           imagePullPolicy: "IfNotPresent"

--- a/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
@@ -25,10 +25,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
-            - name: MY_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/mock.socket
           imagePullPolicy: "IfNotPresent"

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,0 +1,5 @@
+package util
+
+var (
+	EnvNodeName = "NODE_NAME"
+)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

When I added unit test for this project, I found we didn't give an initial value for `agent.nodeName`. Actually, it was used in event handler package. If `agent.nodeName` is nil, agent cannot work fine.

**Special notes for your reviewer**:

There are two approaches can help the container of the pod find the node name

1. [use reference environment variable](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables) 
2. [get node name from CSINode](https://kubernetes-csi.github.io/docs/csi-node-object.html#what-fields-does-the-csinode-object-have)

I think 2nd method is more available for CSI service. So I used it in this PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None

```
