### PR TITLE
feature: send the recovery event when volume returns to the healthy state

### DIFF
--- a/cmd/csi-external-health-monitor-agent/main.go
+++ b/cmd/csi-external-health-monitor-agent/main.go
@@ -146,7 +146,7 @@ func main() {
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: clientset.CoreV1().Events(v1.NamespaceAll)})
 	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("csi-pv-monitor-agent-%s", storageDriver)})
 	monitorAgent, err := monitoragent.NewPVMonitorAgent(clientset, storageDriver, csiConn, *timeout, *monitorInterval, factory.Core().V1().PersistentVolumes(),
-		factory.Core().V1().PersistentVolumeClaims(), factory.Core().V1().Pods(), supportStageUnstage, *kubeletRootPath, eventRecorder)
+		factory.Core().V1().PersistentVolumeClaims(), factory.Core().V1().Pods(), factory.Core().V1().Events(), supportStageUnstage, *kubeletRootPath, eventRecorder)
 	if err != nil {
 		klog.Error(err.Error())
 		os.Exit(1)

--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -185,7 +185,7 @@ func main() {
 	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("csi-pv-monitor-controller-%s", option.DriverName)})
 
 	monitorController := monitorcontroller.NewPVMonitorController(clientset, csiConn, factory.Core().V1().PersistentVolumes(),
-		factory.Core().V1().PersistentVolumeClaims(), factory.Core().V1().Pods(), factory.Core().V1().Nodes(), eventRecorder, &option)
+		factory.Core().V1().PersistentVolumeClaims(), factory.Core().V1().Pods(), factory.Core().V1().Nodes(), factory.Core().V1().Events(), eventRecorder, &option)
 
 	run := func(ctx context.Context) {
 		stopCh := ctx.Done()

--- a/deploy/kubernetes/external-health-monitor-agent/rbac.yaml
+++ b/deploy/kubernetes/external-health-monitor-agent/rbac.yaml
@@ -34,6 +34,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
@@ -35,7 +35,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["event"]
+    resources: ["events"]
     verbs: ["get", "list", "watch", "create", "patch"]
 
 ---

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -98,7 +98,7 @@ func Test_RecoveryEvent(t *testing.T) {
 	}
 
 	testCase := &testCase{
-		name: "normal_volume_case1",
+		name: "recovery_test_case1",
 		fakeNativeObjects: &fakeNativeObjects{
 			MockVolume: normalVolume,
 			MockPod:    pod,

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/external-health-monitor/pkg/mock"
+	"github.com/kubernetes-csi/external-health-monitor/pkg/util"
 )
 
 func Test_AbnormalVolume(t *testing.T) {
@@ -82,7 +83,7 @@ func Test_RecoveryEvent(t *testing.T) {
 			},
 			Condition: &csi.VolumeCondition{
 				Abnormal: false,
-				Message:  "Volume is healthy",
+				Message:  util.DefaultRecoveryEventMessage,
 			},
 		},
 		NativeVolume:      mock.CreatePV(2, "pvc", "pv", mock.DefaultNS, "normalVolume1", "pvcuid", &mock.FSVolumeMode, v1.VolumeBound),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/external-health-monitor/pkg/mock"
+	"github.com/kubernetes-csi/external-health-monitor/pkg/util"
 )
 
 func Test_AbnormalVolumeWithoutNodeWatcher(t *testing.T) {
@@ -195,7 +196,7 @@ func Test_RecoveryEventWithListVolume(t *testing.T) {
 			},
 			Condition: &csi.VolumeCondition{
 				Abnormal: false,
-				Message:  "Volume is healthy",
+				Message:  util.DefaultRecoveryEventMessage,
 			},
 		},
 		NativeVolume:      mock.CreatePV(2, "pvc", "pv", mock.DefaultNS, "normalVolume1", "pvcuid", &mock.FSVolumeMode, v1.VolumeBound),
@@ -228,7 +229,7 @@ func Test_RecoveryEventWithoutListVolume(t *testing.T) {
 			},
 			Condition: &csi.VolumeCondition{
 				Abnormal: false,
-				Message:  "Volume is healthy",
+				Message:  util.DefaultRecoveryEventMessage,
 			},
 		},
 		NativeVolume:      mock.CreatePV(2, "pvc", "pv", mock.DefaultNS, "normalVolume1", "pvcuid", &mock.FSVolumeMode, v1.VolumeBound),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -206,7 +206,7 @@ func Test_RecoveryEventWithListVolume(t *testing.T) {
 		NativeEvent: mock.CreateEvent("event", "", "pvcuid", v1.EventTypeWarning, "VolumeConditionAbnormal"),
 	}
 	testCase := &testCase{
-		name:               "normal_volume_recovery_event",
+		name:               "normal_volume_recovery_event1",
 		enableNodeWatcher:  false,
 		supportListVolumes: true,
 		fakeNativeObjects: &fakeNativeObjects{
@@ -239,7 +239,7 @@ func Test_RecoveryEventWithoutListVolume(t *testing.T) {
 		NativeEvent: mock.CreateEvent("event", "", "pvcuid", v1.EventTypeWarning, "VolumeConditionAbnormal"),
 	}
 	testCase := &testCase{
-		name:               "normal_volume_recovery_event",
+		name:               "normal_volume_recovery_event2",
 		enableNodeWatcher:  false,
 		supportListVolumes: false,
 		fakeNativeObjects: &fakeNativeObjects{

--- a/pkg/csi-handler/pv_checker.go
+++ b/pkg/csi-handler/pv_checker.go
@@ -239,7 +239,7 @@ func (checker *PVHealthConditionChecker) sendRecoveryEventToPVC(pvc *v1.Persiste
 	}
 
 	if len(events) > 0 {
-		checker.eventRecorder.Event(pvc, v1.EventTypeNormal, "VolumeConditionNormal", volumeCondition.GetMessage())
+		checker.eventRecorder.Event(pvc, v1.EventTypeNormal, "VolumeConditionNormal", util.DefaultRecoveryEventMessage)
 	}
 
 	return nil
@@ -258,7 +258,7 @@ func (checker *PVHealthConditionChecker) sendRecoveryEventToPod(pod *v1.Pod, vol
 	}
 
 	if len(events) > 0 {
-		checker.eventRecorder.Event(pod, v1.EventTypeNormal, "VolumeConditionNormal", volumeCondition.GetMessage())
+		checker.eventRecorder.Event(pod, v1.EventTypeNormal, "VolumeConditionNormal", util.DefaultRecoveryEventMessage)
 	}
 
 	return nil

--- a/pkg/csi-handler/pv_checker.go
+++ b/pkg/csi-handler/pv_checker.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -46,13 +47,14 @@ type PVHealthConditionChecker struct {
 	pvcLister corelisters.PersistentVolumeClaimLister
 	pvLister  corelisters.PersistentVolumeLister
 
+	eventInformer coreinformers.EventInformer
+
 	csiPVHandler CSIHandler
 }
 
 // NewPVHealthConditionChecker returns an instance of PVHealthConditionChecker
 func NewPVHealthConditionChecker(name string, conn *grpc.ClientConn, kClient kubernetes.Interface, timeout time.Duration,
-	pvcLister corelisters.PersistentVolumeClaimLister, pvLister corelisters.PersistentVolumeLister, recorder record.EventRecorder) *PVHealthConditionChecker {
-
+	pvcLister corelisters.PersistentVolumeClaimLister, pvLister corelisters.PersistentVolumeLister, eventInformer coreinformers.EventInformer, recorder record.EventRecorder) *PVHealthConditionChecker {
 	return &PVHealthConditionChecker{
 		driverName:    name,
 		csiConn:       conn,
@@ -61,6 +63,7 @@ func NewPVHealthConditionChecker(name string, conn *grpc.ClientConn, kClient kub
 		pvcLister:     pvcLister,
 		pvLister:      pvLister,
 		timeout:       timeout,
+		eventInformer: eventInformer,
 
 		csiPVHandler: NewCSIPVHandler(conn),
 	}
@@ -98,14 +101,23 @@ func (checker *PVHealthConditionChecker) CheckControllerListVolumeStatuses() err
 			continue
 		}
 
-		if result[volumeHandle] != nil && result[volumeHandle].GetAbnormal() {
+		volumeCondition := result[volumeHandle]
+		if volumeCondition == nil {
+			continue
+		}
+
+		pvc, err := checker.pvcLister.PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
+		if err != nil {
+			klog.Errorf("Get PVC error: %+v", err)
+			continue
+		}
+
+		if volumeCondition.GetAbnormal() {
 			// Since pv status is bound, we believe PV controller, do not check pv.Spec.ClaimRef here.
-			pvc, err := checker.pvcLister.PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
-			if err != nil {
-				klog.Errorf("Get PVC error: %+v", err)
-				continue
-			}
-			checker.eventRecorder.Event(pvc, v1.EventTypeWarning, "VolumeConditionAbnormal", result[volumeHandle].GetMessage())
+			checker.eventRecorder.Event(pvc, v1.EventTypeWarning, "VolumeConditionAbnormal", volumeCondition.GetMessage())
+		} else {
+			// Send recovery event if the abnormal event was sent and unexpired
+			return checker.sendRecoveryEventToPVC(pvc, volumeCondition)
 		}
 	}
 
@@ -149,14 +161,18 @@ func (checker *PVHealthConditionChecker) CheckControllerVolumeStatus(pv *v1.Pers
 		return err
 	}
 
+	pvc, err := checker.pvcLister.PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
+	if err != nil {
+		return err
+	}
+
 	// At the first stage, we just send PVC events
 	if volumeCondition.GetAbnormal() {
 		// Since pv status is bound, we believe PV controller, do not check pv.Spec.ClaimRef here.
-		pvc, err := checker.pvcLister.PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(pv.Spec.ClaimRef.Name)
-		if err != nil {
-			return err
-		}
 		checker.eventRecorder.Event(pvc, v1.EventTypeWarning, "VolumeConditionAbnormal", volumeCondition.GetMessage())
+	} else {
+		// Send recovery event if the abnormal event was sent and unexpired
+		return checker.sendRecoveryEventToPVC(pvc, volumeCondition)
 	}
 
 	return nil
@@ -203,6 +219,46 @@ func (checker *PVHealthConditionChecker) CheckNodeVolumeStatus(kubeletRootPath s
 
 	if volumeCondition.GetAbnormal() {
 		checker.eventRecorder.Event(pod, v1.EventTypeWarning, "VolumeConditionAbnormal", volumeCondition.GetMessage())
+	} else {
+		return checker.sendRecoveryEventToPod(pod, volumeCondition)
+	}
+
+	return nil
+}
+
+// sendRecoveryEventToPVC sends the recovery event to the pvc
+// If the volume condition is normal and abnormal event wasn't expired,
+// PVHealthConditionChecker should send recovery event.
+func (checker *PVHealthConditionChecker) sendRecoveryEventToPVC(pvc *v1.PersistentVolumeClaim, volumeCondition *VolumeConditionResult) error {
+	pvcUID := string(pvc.ObjectMeta.GetUID())
+	key := fmt.Sprintf("%s:%s:%s", pvcUID, v1.EventTypeWarning, "VolumeConditionAbnormal")
+	events, err := checker.eventInformer.Informer().GetIndexer().ByIndex(util.DefaultEventIndexerName, key)
+	if err != nil {
+		klog.Warningf("Get abnormal event from indexer failed: %+v", err)
+		return nil
+	}
+
+	if len(events) > 0 {
+		checker.eventRecorder.Event(pvc, v1.EventTypeNormal, "VolumeConditionNormal", volumeCondition.GetMessage())
+	}
+
+	return nil
+}
+
+// sendRecoveryEventToPod sends the recovery event to the pod
+// If the volume condition is normal and abnormal event wasn't expired,
+// PVHealthConditionChecker should send recovery event.
+func (checker *PVHealthConditionChecker) sendRecoveryEventToPod(pod *v1.Pod, volumeCondition *VolumeConditionResult) error {
+	podUID := string(pod.ObjectMeta.GetUID())
+	key := fmt.Sprintf("%s:%s:%s", podUID, v1.EventTypeWarning, "VolumeConditionAbnormal")
+	events, err := checker.eventInformer.Informer().GetIndexer().ByIndex(util.DefaultEventIndexerName, key)
+	if err != nil {
+		klog.Warningf("Get abnormal event from indexer failed: %+v", err)
+		return nil
+	}
+
+	if len(events) > 0 {
+		checker.eventRecorder.Event(pod, v1.EventTypeNormal, "VolumeConditionNormal", volumeCondition.GetMessage())
 	}
 
 	return nil

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -30,6 +30,7 @@ var (
 	DefaultKubeletPath = "/var/lib/kubelet"
 	FSVolumeMode       = v1.PersistentVolumeBlock
 	AbnormalEvent      = "Warning VolumeConditionAbnormal Volume not found"
+	NormalEvent        = "Normal VolumeConditionNormal Volume is healthy"
 	ErrorWatchTimeout  = errors.New("watch event timeout")
 )
 
@@ -44,6 +45,10 @@ type MockNode struct {
 
 type MockPod struct {
 	NativePod *v1.Pod
+}
+
+type MockEvent struct {
+	NativeEvent *v1.Event
 }
 
 type MockVolume struct {
@@ -199,6 +204,20 @@ func createPV(capacityGB int, pvcName, name, pvcNamespace string, pvcUID types.U
 	return pv
 }
 
+func createEvent(name, namespace, uid, eventType, eventReason string) *v1.Event {
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		InvolvedObject: v1.ObjectReference{
+			UID: types.UID(uid),
+		},
+		Type:   eventType,
+		Reason: eventReason,
+	}
+}
+
 func CreatePVWithoutCSIDriver(capacityGB int, pvcName, name, pvcNamespace string, pvcUID types.UID, volumeId string, volumePhase v1.PersistentVolumePhase, volumeMode *v1.PersistentVolumeMode) *v1.PersistentVolume {
 	pv := createPV(capacityGB, pvcName, name, pvcNamespace, pvcUID, volumeId, volumePhase, volumeMode)
 	pv.Spec.CSI = nil
@@ -234,6 +253,10 @@ func CreateNode(name, namespace string) *v1.Node {
 
 func CreatePod(name, namespace, volumeName, pvcName, nodeName, uid string, pvcReadOnly bool) *v1.Pod {
 	return createPod(name, namespace, volumeName, pvcName, nodeName, uid, pvcReadOnly)
+}
+
+func CreateEvent(name, namespace, uid, eventType, eventReason string) *v1.Event {
+	return createEvent(name, namespace, uid, eventType, eventReason)
 }
 
 func WatchEvent(want bool, eventChan <-chan string) (string, error) {

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -30,7 +30,7 @@ var (
 	DefaultKubeletPath = "/var/lib/kubelet"
 	FSVolumeMode       = v1.PersistentVolumeBlock
 	AbnormalEvent      = "Warning VolumeConditionAbnormal Volume not found"
-	NormalEvent        = "Normal VolumeConditionNormal Volume is healthy"
+	NormalEvent        = "Normal VolumeConditionNormal The Volume returns to the healthy state"
 	ErrorWatchTimeout  = errors.New("watch event timeout")
 )
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,6 +34,7 @@ const (
 	DefaultKubeletPodsDirName    = "pods"
 	DefaultKubeletVolumesDirName = "volumes"
 	DefaultEventIndexerName      = "event-uid"
+	DefaultRecoveryEventMessage  = "The Volume returns to the healthy state"
 )
 
 // MakeDeviceMountPath generates device mount path

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,6 +33,7 @@ const (
 	globalMountInGlobalPath      = "globalmount"
 	DefaultKubeletPodsDirName    = "pods"
 	DefaultKubeletVolumesDirName = "volumes"
+	DefaultEventIndexerName      = "event-uid"
 )
 
 // MakeDeviceMountPath generates device mount path


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

1. Constructs an indexer of event for improving efficiency when we want to get historical abnormal events
2. Send the recovery event when the volume returns to the healthy state and abnormal event we sent before was found

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Send the recovery event when volume returns to the healthy state
```
