### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -39,10 +39,11 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Changes can then be updated in all the sidecar repos and hostpath driver repo
    by following the [update
    instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/master/README.md#sharing-and-updating).
-1. New pull and CI jobs are configured by
+1. New pull and CI jobs are configured by adding new K8s versions to the top of
    [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/gen-jobs.sh).
-   New pull jobs that have been unverified should be initially made optional.
-   [Example](https://github.com/kubernetes/test-infra/pull/15055)
+   New pull jobs that have been unverified should be initially made optional by
+   setting the new K8s version as
+   [experimental](https://github.com/kubernetes/test-infra/blob/a1858f46d6014480b130789df58b230a49203a64/config/jobs/kubernetes-csi/gen-jobs.sh#L40).
 1. Once new pull and CI jobs have been verified, and the new Kubernetes version
    is released, we can make the optional jobs required, and also remove the
    Kubernetes versions that are no longer supported.
@@ -54,14 +55,19 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
   generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 1. Generate release notes for the release. Replace arguments with the relevant
   information.
+    * Clean up old cached information (also needed if you are generating release
+      notes for multiple repos)
+      ```bash
+      rm -rf /tmp/k8s-repo
+      ```
     * For new minor releases on master:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md
         ```
     * For new patch releases on a release branch:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=patch-to-latest --branch=release-1.1
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -211,6 +211,10 @@ configvar CSI_PROW_DRIVER_INSTALL "install_csi_driver" "name of the shell functi
 # still use that name.
 configvar CSI_PROW_DRIVER_CANARY "${CSI_PROW_HOSTPATH_CANARY}" "driver image override for canary images"
 
+# Image registry to use for canary images.
+# Only valid if CSI_PROW_DRIVER_CANARY == "canary".
+configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "registry for canary images"
+
 # The E2E testing can come from an arbitrary repo. The expectation is that
 # the repo supports "go test ./test/e2e -args --storage.testdriver" (https://github.com/kubernetes/kubernetes/pull/72836)
 # after setting KUBECONFIG. As a special case, if the repository is Kubernetes,
@@ -693,7 +697,11 @@ install_csi_driver () {
     fi
 
     if [ "${CSI_PROW_DRIVER_CANARY}" != "stable" ]; then
+      if [ "${CSI_PROW_DRIVER_CANARY}" == "canary" ]; then
+        images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY} IMAGE_REGISTRY=${CSI_PROW_DRIVER_CANARY_REGISTRY}"
+      else
         images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY}"
+      fi
     fi
     # Ignore: Double quote to prevent globbing and word splitting.
     # It's intentional here for $images.


### PR DESCRIPTION
Replace "release-tools" with a squashed commit.

Squashed 'release-tools/' changes from 4cf843f..a0f195c

[a0f195c](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195c) Merge pull request #106 from msau42/fix-canary
[7100c12](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c12) Only set staging registry when running canary job
[b3c65f9](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9) Merge pull request #99 from msau42/add-release-process
[e53f3e8](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e8) Merge pull request #103 from msau42/fix-canary
[d129462](https://github.com/kubernetes-csi/csi-release-tools/commit/d129462) Document new method for adding CI jobs are new K8s versions
[e73c2ce](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce) Use staging registry for canary tests
[2c09846](https://github.com/kubernetes-csi/csi-release-tools/commit/2c09846) Add cleanup instructions to release-notes generation
[60e1cd3](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c09](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c09) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636) Merge pull request #97 from pohly/go-1.15
[82d108a](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108a) switch to Go 1.15
[d8a2530](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a2530) Merge pull request #95 from msau42/add-release-process
[843bddc](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddc) Add steps on promoting release images
[0345a83](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a83) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d5](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d5) cloud build: bump timeout in Prow job
[41ec6d1](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d1) Merge pull request #93 from animeshk08/patch-1
[5a54e67](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67) filter-junit: Fix gofmt error
[0676fcb](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcb) Merge pull request #92 from animeshk08/patch-1
[36ea4ff](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ff) filter-junit: Fix golint error
[f5a4203](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a4203) Merge pull request #91 from cyb70289/arm64
[43e50d6](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6) prow.sh: enable building arm64 image
[0d5bd84](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd84) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7) cloud build: k8s-staging-sig-storage
[c5fd961](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd961) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7) cloud build: initialize support for running commands in Dockerfile
[be902f4](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f4) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082) build.make: optional inclusion of Windows in multiarch images
[5231f05](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05) build.make: properly declare push-multiarch
[4569f27](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27) build.make: fix push-multiarch ambiguity
[17dde9e](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9e) Merge pull request #87 from pohly/cloud-build
[bd41690](https://github.com/kubernetes-csi/csi-release-tools/commit/bd41690) cloud build: initial set of shared files
[9084fec](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fec) Merge pull request #81 from msau42/add-release-process
[6f2322e](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e) Update patch release notes generation command
[0fcc3b1](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fe](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fe) Support local snapshot RBAC for pull jobs
[c1bdf5b](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5b) Merge pull request #80 from msau42/add-release-process
[ea1f94a](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94a) update release tools instructions
[152396e](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc146](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc146) Update snapshotter to version 2.0.1

git-subtree-dir: release-tools
git-subtree-split: a0f195cc2ddc2a1f07d4d3e46fc08187db358f94

```release-note
NONE
```