### PR TITLE
added labels to the resources to be used for collective operation

### DIFF
--- a/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
+++ b/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
@@ -6,6 +6,8 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-external-health-monitor-agent
+  labels:
+    app: csi-health-monitor
 spec:
   selector:
     matchLabels:

--- a/deploy/kubernetes/external-health-monitor-agent/rbac.yaml
+++ b/deploy/kubernetes/external-health-monitor-agent/rbac.yaml
@@ -14,6 +14,8 @@ metadata:
   name: csi-external-health-monitor-agent
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-health-monitor
 
 ---
 # Health monitor agent must be able to work with PVs, PVCs, Nodes and Pods
@@ -21,6 +23,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-health-monitor-agent-runner
+  labels:
+    app: csi-health-monitor
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -43,6 +47,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-external-health-monitor-agent-role
+  labels:
+    app: csi-health-monitor
 subjects:
   - kind: ServiceAccount
     name: csi-external-health-monitor-agent

--- a/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-external-health-monitor-controller
+  labels:
+    app: csi-health-monitor
 spec:
   replicas: 3
   selector:

--- a/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
@@ -14,6 +14,8 @@ metadata:
   name: csi-external-health-monitor-controller
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-health-monitor
 
 ---
 # Health monitor controller must be able to work with PVs, PVCs, Nodes and Pods
@@ -21,6 +23,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-health-monitor-controller-runner
+  labels:
+    app: csi-health-monitor
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -43,6 +47,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-external-health-monitor-controller-role
+  labels:
+    app: csi-health-monitor
 subjects:
   - kind: ServiceAccount
     name: csi-external-health-monitor-controller
@@ -62,6 +68,8 @@ metadata:
   # replace with non-default namespace name
   namespace: default
   name: external-health-monitor-controller-cfg
+  labels:
+    app: csi-health-monitor
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -74,6 +82,8 @@ metadata:
   name: csi-external-health-monitor-controller-role-cfg
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-health-monitor
 subjects:
   - kind: ServiceAccount
     name: csi-external-health-monitor-controller


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
We need to add the common/generic labels to all the resources which are being deployed as the part of any csi driver. It is the part of this [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/216)

Special notes for your reviewer:
Since there was no common labels to identify all the items in one set of resources installed, these labels can help us to identify resources and operate on them in a collective manner

Does this PR introduce a user-facing change?:

NONE
