### PR TITLE
Introducing the http-endpoint flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Check if there are events on PVCs or Pods that report abnormal volume condition 
 
 - `leader-election-namespace <namespace>`: The namespace where the leader election resource exists. Defaults to the pod namespace if not set.
 
-- `metrics-address`: The TCP network address where the Prometheus metrics endpoint and leader election health check will run (example: :8080, which corresponds to port 8080 on local host). The default is the empty string, which means the metrics and leader election check endpoint is disabled.
+- `http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 - `metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is /metrics.
 
@@ -114,12 +114,13 @@ Check if there are events on PVCs or Pods that report abnormal volume condition 
 
 - `node-list-add-interval <duration>`: Interval of listing nodes and adding them. It is used together with `monitor-interval` and `enable-node-watcher` by nodeWatcher.
 
+- `metrics-address`: (deprecated) The TCP network address where the Prometheus metrics endpoint will run (example: :8080, which corresponds to port 8080 on local host). The default is the empty string, which means the metrics and leader election check endpoint is disabled.
 
 ## csi-external-health-monitor-agent-sidecar-command-line-options
 
 ### Important optional arguments that are highly recommended to be used
 
-- `metrics-address`: The TCP network address where the prometheus metrics endpoint will run (example: :8080, which corresponds to port 8080 on localhost). The default is the empty string, which means the metrics endpoint is disabled.
+- `http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 - `metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is /metrics.
 
@@ -141,11 +142,13 @@ Check if there are events on PVCs or Pods that report abnormal volume condition 
 
 - `kubelet-root-path`: Path to kubelet. It is used to generate the volume path. `/var/lib/kubelet` by default if not set.
 
+- `metrics-address`: (deprecated) The TCP network address where the prometheus metrics endpoint will run (example: :8080, which corresponds to port 8080 on localhost). The default is the empty string, which means the metrics endpoint is disabled.
+
 ### HTTP endpoint
 
 Both sidecars optionally exposes an HTTP endpoint at
-address:port specified by `--metrics-address` argument. When set,
-these two paths may be exposed:
+address:port, specified by the `--http-endpoint` argument. When set, these two
+paths may be exposed:
 
 * Metrics path, as set by `--metrics-path` argument (default is
   `/metrics`) - both sidecars.

--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -68,7 +68,8 @@ var (
 	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 
-	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
+	metricsAddress = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
+	httpEndpoint   = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 )
 
@@ -86,6 +87,15 @@ func main() {
 		return
 	}
 	klog.Infof("Version: %s", version)
+
+	if *metricsAddress != "" && *httpEndpoint != "" {
+		klog.Error("only one of `--metrics-address` and `--http-endpoint` can be set.")
+		os.Exit(1)
+	}
+	addr := *metricsAddress
+	if addr == "" {
+		addr = *httpEndpoint
+	}
 
 	// Create the client config. Use kubeconfig if given, otherwise assume in-cluster.
 	config, err := buildConfig(*kubeconfig)
@@ -135,12 +145,13 @@ func main() {
 
 	// Prepare HTTP endpoint for metrics + leader election healthz
 	mux := http.NewServeMux()
-	if *metricsAddress != "" {
+	if addr != "" {
 		metricsManager.RegisterToServer(mux, *metricsPath)
 		go func() {
-			err := http.ListenAndServe(*metricsAddress, mux)
+			klog.Infof("ServeMux listening at %q", addr)
+			err := http.ListenAndServe(addr, mux)
 			if err != nil {
-				klog.Fatalf("Failed to start Prometheus metrics endpoint on specified address (%q) and path (%q): %s", *metricsAddress, *metricsPath, err)
+				klog.Fatalf("Failed to start HTTP server at specified address (%q) and metrics path (%q): %s", addr, *metricsPath, err)
 			}
 		}()
 	}
@@ -211,7 +222,9 @@ func main() {
 		// Name of config map with leader election lock
 		lockName := "external-health-monitor-leader-" + storageDriver
 		le := leaderelection.NewLeaderElection(clientset, lockName, run)
-		le.PrepareHealthCheck(mux, leaderelection.DefaultHealthCheckTimeout)
+		if *httpEndpoint != "" {
+			le.PrepareHealthCheck(mux, leaderelection.DefaultHealthCheckTimeout)
+		}
 
 		if *leaderElectionNamespace != "" {
 			le.WithNamespace(*leaderElectionNamespace)

--- a/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
+++ b/deploy/kubernetes/external-health-monitor-agent/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
-            - "--metrics-address=:8080"
+            - "--http-endpoint=:8080"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -36,7 +36,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - containerPort: 8080
-              name: metrics
+              name: http-endpoint
               protocol: TCP
 
         - name: mock-driver

--- a/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
+++ b/deploy/kubernetes/external-health-monitor-controller/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
-            - "--metrics-address=:8080"
+            - "--http-endpoint=:8080"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/mock.socket
@@ -36,13 +36,13 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - containerPort: 8080
-              name: metrics
+              name: http-endpoint
               protocol: TCP
           livenessProbe:
             failureThreshold: 1
             httpGet:
               path: /healthz/leader-election
-              port: metrics
+              port: http-endpoint
             initialDelaySeconds: 10
             timeoutSeconds: 10
             periodSeconds: 20


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Using a more generic flag name

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: Similar to https://github.com/kubernetes-csi/external-attacher/pull/279 and later changes

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
For both the external-health-monitor-controller and external-health-monitor-agent, the `metrics-address` flag is deprecated and replaced by `http-endpoint`, which enables handlers from both metrics manager and leader election health check.
```

/assign @pohly 