### PR TITLE
Remove references to "local" PVs

### DIFF
--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -63,7 +63,7 @@ var (
 	volumeListAndAddInterval = flag.Duration("volume-list-add-interval", 5*time.Minute, "Time interval for listing volumes and add them to queue")
 	nodeListAndAddInterval   = flag.Duration("node-list-add-interval", 5*time.Minute, "Time interval for listing nodess and add them to queue")
 	workerThreads            = flag.Uint("worker-threads", 10, "Number of pv monitor worker threads")
-	enableNodeWatcher        = flag.Bool("enable-node-watcher", false, "whether we want to enable node watcher, node watcher will only have effects on local PVs now, it may be useful for block storages too, will take this into account later.")
+	enableNodeWatcher        = flag.Bool("enable-node-watcher", false, "Indicates whether the node watcher is enabled or not.")
 
 	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")

--- a/pkg/controller/node_watcher.go
+++ b/pkg/controller/node_watcher.go
@@ -272,12 +272,12 @@ func (watcher *NodeWatcher) isNodeBroken(node *v1.Node) bool {
 }
 
 func (watcher *NodeWatcher) deleteNode(key string, node *v1.Node) {
-	klog.Infof("node:%s is deleted, so mark the local PVs on it", node.Name)
+	klog.Infof("node:%s is deleted, so mark the PVs on the node", node.Name)
 
-	// mark all local PVs on this node
+	// mark all PVs on this node
 	err := watcher.markPVCsAndPodsOnUnhealthyNode(node)
 	if err != nil {
-		klog.Errorf("marking local PVs failed: %v", err)
+		klog.Errorf("marking PVs failed: %v", err)
 		// must re-enqueue here, because we can not get this from informer(node-lister) any more
 		watcher.enqueueWork(node)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The node watcher feature can be used by any PV mounted on a node, not just local PV.  Remove the wording of "local" in this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
