### PR TITLE
remove the build option of agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all csi-external-health-monitor-controller csi-external-health-monitor-agent clean test
+.PHONY: all csi-external-health-monitor-controller clean test
 
-CMDS=csi-external-health-monitor-controller csi-external-health-monitor-agent
+CMDS=csi-external-health-monitor-controller 
 all: build
 
 include release-tools/build.make


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

remove the build option for agent image so that we don't need to maintain the agent image anymore. It's temporary workaround before the https://github.com/kubernetes-csi/external-health-monitor/pull/63 was merged

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 remove the build option for agent 
```
