### PR TITLE
Add command line arguments to configure leader election options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Check if there are events on PVCs or Pods that report abnormal volume condition 
 
 - `leader-election-namespace <namespace>`: The namespace where the leader election resource exists. Defaults to the pod namespace if not set.
 
+- `leader-election-lease-duration <duration>`: Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.
+
+- `leader-election-renew-deadline <duration>`: Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.
+
+- `leader-election-retry-period <duration>`: Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.
+
 - `http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 - `metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is /metrics.

--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -65,8 +65,11 @@ var (
 	workerThreads            = flag.Uint("worker-threads", 10, "Number of pv monitor worker threads")
 	enableNodeWatcher        = flag.Bool("enable-node-watcher", false, "Indicates whether the node watcher is enabled or not.")
 
-	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
-	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
+	enableLeaderElection        = flag.Bool("leader-election", false, "Enable leader election.")
+	leaderElectionNamespace     = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
+	leaderElectionLeaseDuration = flag.Duration("leader-election-lease-duration", 15*time.Second, "Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.")
+	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
+	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 
 	metricsAddress = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	httpEndpoint   = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
@@ -229,6 +232,10 @@ func main() {
 		if *leaderElectionNamespace != "" {
 			le.WithNamespace(*leaderElectionNamespace)
 		}
+
+		le.WithLeaseDuration(*leaderElectionLeaseDuration)
+		le.WithRenewDeadline(*leaderElectionRenewDeadline)
+		le.WithRetryPeriod(*leaderElectionRetryPeriod)
 
 		if err := le.Run(); err != nil {
 			klog.Fatalf("failed to initialize leader election: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds command-line arguments for leader election options - Lease Duration, Renew Deadline, and Retry Period. Currently, the defaults are 15, 10, and 5 seconds respectively. Without this change, there's no way for a customer/storage plugin to configure those values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89

**Special notes for your reviewer**:
Testing:
Modified the deployment under deploy/kubernetes/external-health-monitor-controller to specify new command-line options.
```
        - name: csi-external-health-monitor-controller
          # Currently, canary is needed for healthz/leader-election.
          image: harbor-repo.vmware.com/dkinni/csi-external-health-monitor-controller:le-test-2
          imagePullPolicy: Always
          args:
            - "--v=5"
            - "--csi-address=$(ADDRESS)"
            - "--leader-election"
            - "--leader-election-lease-duration=30s"
            - "--leader-election-renew-deadline=20s"
            - "--leader-election-retry-period=10s"
            - "--http-endpoint=:8080"
```

Verified that the csi-external-health-monitor-controller is up

```
dkinni@dkinni-a02 external-health-monitor % kubectl get deployment csi-external-health-monitor-controller                
NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
csi-external-health-monitor-controller   3/3     3            3           18m
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add command line arguments `leader-election-lease-duration`, `leader-election-renew-deadline`, and `leader-election-retry-period` to configure leader election options for the external health monitor controller.
```
Signed-off-by: Deepak Kinni <dkinni@vmware.com>