### PR TITLE
staging_target_path for Block PV is incorrect

### DIFF
--- a/pkg/csi-handler/pv_checker.go
+++ b/pkg/csi-handler/pv_checker.go
@@ -207,7 +207,7 @@ func (checker *PVHealthConditionChecker) CheckNodeVolumeStatus(kubeletRootPath s
 	volumePath = util.GetVolumePath(kubeletRootPath, pv.Name, string(pod.UID), isBlock)
 
 	if supportStageUnstage {
-		stagingTargetPath, err = util.MakeDeviceMountPath(kubeletRootPath, pv)
+		stagingTargetPath, err = util.MakeDeviceMountPath(kubeletRootPath, pv, isBlock)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -39,15 +39,19 @@ const (
 )
 
 // MakeDeviceMountPath generates device mount path
-func MakeDeviceMountPath(kubeletRootDir string, pv *v1.PersistentVolume) (string, error) {
+func MakeDeviceMountPath(kubeletRootDir string, pv *v1.PersistentVolume, isBlock bool) (string, error) {
 	if pv.Name == "" {
 		return "", fmt.Errorf("makeDeviceMountPath failed, pv name empty")
 	}
 
 	pluginsDir := path.Join(kubeletRootDir, DefaultKubeletPluginsDirName)
 	csiPluginDir := path.Join(pluginsDir, CSIPluginName)
+	if !isBlock {
+		return path.Join(csiPluginDir, persistentVolumeInGlobalPath, pv.Name, globalMountInGlobalPath), nil
+	} else {
+		return path.Join(csiPluginDir, DefaultKubeletBlockVolumesDirName, "staging", pv.Name), nil
+	}
 
-	return path.Join(csiPluginDir, persistentVolumeInGlobalPath, pv.Name, globalMountInGlobalPath), nil
 }
 
 // GetVolumePath generates volume path

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -36,13 +36,18 @@ func TestGetVolumePath(t *testing.T) {
 func TestMakeDeviceMountPath(t *testing.T) {
 	assert := assert.New(t)
 	// Negative Case: pvName is nil
-	_, err := MakeDeviceMountPath("", &v1.PersistentVolume{})
+	_, err := MakeDeviceMountPath("", &v1.PersistentVolume{}, false)
 	assert.NotNil(err)
 
 	// Positive Case: pvName is "pv-test"
 	expectedMountPath := "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-431ceccf-7999-11ea-ab4a-fa163ffd8213/globalmount"
 	pv := &v1.PersistentVolume{}
 	pv.Name = "pvc-431ceccf-7999-11ea-ab4a-fa163ffd8213"
-	actualMountPath, err := MakeDeviceMountPath(kubeletRootDir, pv)
+
+	actualMountPath, err := MakeDeviceMountPath(kubeletRootDir, pv, false)
 	assert.Equal(expectedMountPath, actualMountPath)
+
+	expectedBlockMountPath := "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc431ceccf-7999-11ea-ab4a-fa163ffd8213"
+	actualBlockMountPath, err := MakeDeviceMountPath(kubeletRootDir, pv, true)
+	assert.Equal(expectedBlockMountPath, actualBlockMountPath)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:
When using block type PV, the format of staging_target_path provided by kubelet is inconsistent with that of csi-external-health-monitor-agent.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/kubernetes-csi/external-health-monitor/issues/112

**Special notes for your reviewer**:
