### PR TITLE
release-0.4: update release-tools

### DIFF
--- a/release-tools/go-get-kubernetes.sh
+++ b/release-tools/go-get-kubernetes.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 # This script can be used while converting a repo from "dep" to "go mod"
 # by calling it after "go mod init" or to update the Kubernetes packages
 # in a repo that has already been converted. Only packages that are


### PR DESCRIPTION
Squashed 'release-tools/' changes from e4dab7f..d29a2e7

[d29a2e7](https://github.com/kubernetes-csi/csi-release-tools/commit/d29a2e7) Merge [pull request #198](https://github.com/kubernetes-csi/csi-release-tools/pull/198) from pohly/csi-test-5.0.0
[41cb70d](https://github.com/kubernetes-csi/csi-release-tools/commit/41cb70d) prow.sh: sanity testing with csi-test v5.0.0
[c85a63f](https://github.com/kubernetes-csi/csi-release-tools/commit/c85a63f) Merge [pull request #197](https://github.com/kubernetes-csi/csi-release-tools/pull/197) from pohly/fix-alpha-testing
[b86d8e9](https://github.com/kubernetes-csi/csi-release-tools/commit/b86d8e9) support Kubernetes 1.25 + Ginkgo v2
[ab0b0a3](https://github.com/kubernetes-csi/csi-release-tools/commit/ab0b0a3) Merge [pull request #192](https://github.com/kubernetes-csi/csi-release-tools/pull/192) from andyzhangx/patch-1
[7bbab24](https://github.com/kubernetes-csi/csi-release-tools/commit/7bbab24) Merge [pull request #196](https://github.com/kubernetes-csi/csi-release-tools/pull/196) from humblec/non-alpha
[e51ff2c](https://github.com/kubernetes-csi/csi-release-tools/commit/e51ff2c) introduce control variable for non alpha feature gate configuration
[ca19ef5](https://github.com/kubernetes-csi/csi-release-tools/commit/ca19ef5) Merge [pull request #195](https://github.com/kubernetes-csi/csi-release-tools/pull/195) from pohly/fix-alpha-testing
[3948331](https://github.com/kubernetes-csi/csi-release-tools/commit/3948331) fix testing with latest Kubernetes
[9a0260c](https://github.com/kubernetes-csi/csi-release-tools/commit/9a0260c) fix boilerplate header

git-subtree-dir: release-tools
git-subtree-split: d29a2e7547822371ebf3e61f7d2249c244879f85

```release-note
NONE
```