### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"errors"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 	"time"
@@ -108,8 +107,7 @@ func createMockServer(t *testing.T, tmpdir string) (*gomock.Controller,
 
 func tempDir(t *testing.T) string {
 	assert := assert.New(t)
-	dir, err := ioutil.TempDir("", "external-provisioner-test")
-	assert.Nil(err)
+	dir := t.TempDir()
 	return dir
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
