### PR TITLE
main: Be more verbose if quitting early from misconfiguration

### DIFF
--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -180,7 +180,7 @@ func main() {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	if !supportsService {
-		logger.V(2).Info("CSI driver does not support Plugin Controller Service, exiting")
+		logger.Info("CSI driver does not support Plugin Controller Service, exiting")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
@@ -203,7 +203,7 @@ func main() {
 	}
 
 	if (!supportControllerListVolumes && !supportControllerGetVolume) || !supportControllerVolumeCondition {
-		logger.V(2).Info("CSI driver does not support Controller ListVolumes and GetVolume service or does not implement VolumeCondition, exiting")
+		logger.Info("CSI driver does not support Controller ListVolumes and GetVolume service or does not implement VolumeCondition, exiting")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 


### PR DESCRIPTION
If the driver lacks support for usefully running the health monitor, be verbose by default about why we are exiting.  The resulting logs will be handy in pointing the driver developer what thy might have done wrong in their CSI implementation, even if they didn't pass in a non-default --v=2.

Fixes: https://github.com/kubernetes-csi/external-health-monitor/issues/305

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Make it easier for CSI driver developers to learn if they are using this sidecar incorrectly (for example, if the driver forgot to expose a feature this sidecar relies on).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #305

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
