### PR TITLE
Update release tools

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.25.5" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.25.7" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
Squashed 'release-tools/' changes from 707a99ec..1e81e752
1e81e752 Merge pull request #293 from andyzhangx/patch-9
4dc18505 fix: upgrade to go1.25.7 to fix https://github.com/advisories/GHSA-5mh9-3jwc-rp59
b60b9a50 Merge pull request #292 from andyzhangx/patch-8
0e4e2ed0 Update Go version from 1.25.5 to 1.25.6 to fix CVE

git-subtree-dir: release-tools
git-subtree-split: 1e81e752e87e027311be882279eac9e292705aa5

> /kind cleanup

```release-note
NONE
```
