### PR TITLE
Fix release on leader election code for health monitor

### DIFF
--- a/cmd/csi-external-health-monitor-controller/main.go
+++ b/cmd/csi-external-health-monitor-controller/main.go
@@ -254,12 +254,13 @@ func main() {
 	run := func(ctx context.Context) {
 		if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
 			var wg sync.WaitGroup
-			stopCh := controllerCtx.Done()
-			factory.Start(stopCh)
+			factory.Start(ctx.Done())
 			monitorController.Run(controllerCtx, int(*workerThreads), &wg)
+			<-controllerCtx.Done()
+			wg.Wait()
+			terminate()
 		} else {
-			stopCh := ctx.Done()
-			factory.Start(stopCh)
+			factory.Start(ctx.Done())
 			monitorController.Run(ctx, int(*workerThreads), nil)
 		}
 	}

--- a/pkg/controller/pv_monitor_controller.go
+++ b/pkg/controller/pv_monitor_controller.go
@@ -28,7 +28,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -38,7 +37,6 @@ import (
 	"k8s.io/klog/v2"
 
 	handler "github.com/kubernetes-csi/external-health-monitor/pkg/csi-handler"
-	"github.com/kubernetes-csi/external-health-monitor/pkg/features"
 	"github.com/kubernetes-csi/external-health-monitor/pkg/util"
 )
 
@@ -233,51 +231,37 @@ func (ctrl *PVMonitorController) Run(ctx context.Context, workers int, wg *sync.
 	// TODO: we need to cache the PVs info and get the diff so that we can identify the NotFound error
 	// if storage support List Volumes RPC, ListVolumes is preferred for performance reasons
 	if ctrl.supportListVolumes {
-		if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				wait.UntilWithContext(ctx, ctrl.checkPVsHealthConditionByListVolumes, ctrl.ListVolumesInterval)
-			}()
-		} else {
-			go wait.UntilWithContext(ctx, ctrl.checkPVsHealthConditionByListVolumes, ctrl.ListVolumesInterval)
-		}
-	} else {
-		if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
-			for i := 0; i < workers; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					wait.UntilWithContext(ctx, ctrl.checkPVWorker, ctrl.PVWorkerExecuteInterval)
-				}()
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				wait.UntilWithContext(ctx, func(ctx context.Context) {
-					logger := klog.FromContext(ctx)
-					err := ctrl.AddPVsToQueue()
-					if err != nil {
-						logger.Error(err, "Failed to reconcile volumes")
-					}
-				}, ctrl.VolumeListAndAddInterval)
-			}()
-		} else {
-			for i := 0; i < workers; i++ {
-				go wait.UntilWithContext(ctx, ctrl.checkPVWorker, ctrl.PVWorkerExecuteInterval)
-			}
-
-			go wait.UntilWithContext(ctx, func(ctx context.Context) {
-				logger := klog.FromContext(ctx)
-				err := ctrl.AddPVsToQueue()
-				if err != nil {
-					logger.Error(err, "Failed to reconcile volumes")
-				}
-			}, ctrl.VolumeListAndAddInterval)
-		}
+		goTrack(wg, func() {
+			wait.UntilWithContext(ctx, ctrl.checkPVsHealthConditionByListVolumes, ctrl.ListVolumesInterval)
+		})
+		<-ctx.Done()
+		return
 	}
 
+	for i := 0; i < workers; i++ {
+		goTrack(wg, func() {
+			wait.UntilWithContext(ctx, ctrl.checkPVWorker, ctrl.PVWorkerExecuteInterval)
+		})
+	}
+	goTrack(wg, func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			logger := klog.FromContext(ctx)
+			err := ctrl.AddPVsToQueue()
+			if err != nil {
+				logger.Error(err, "Failed to reconcile volumes")
+			}
+		}, ctrl.VolumeListAndAddInterval)
+	})
+
 	<-ctx.Done()
+}
+
+func goTrack(wg *sync.WaitGroup, f func()) {
+	if wg != nil {
+		wg.Go(f)
+	} else {
+		go f()
+	}
 }
 
 func waitForCacheSyncSucceed(ctx context.Context, ctrl *PVMonitorController) bool {


### PR DESCRIPTION
Fix the code for leader election to wait on `WaitGroup`.

Also cleanup duplicate code in release on exit.
